### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,12 +1,12 @@
 Revision history for Dist-Zilla-App-Command-podpreview
 
-0.003   02/08/2013
-        * fix use of smartmatch (warns as experimental in 5.18) (ether)
-        * fix misspelled function name (ether)
-        * fix dist name in Changes (ether)
+0.003 2013-08-02
+    - fix use of smartmatch (warns as experimental in 5.18) (ether)
+    - fix misspelled function name (ether)
+    - fix dist name in Changes (ether)
 
-0.002   01/04/2011
-        * Fix error in pod
+0.002 2011-04-01
+    - Fix error in pod
 
-0.001   01/04/2011
-        * Initial upload to CPAN
+0.001 2011-04-01
+    - Initial upload to CPAN


### PR DESCRIPTION
Hi,

I've reformatted your Changes file according to the spec in CPAN::Changes::Spec.

Following this format means that various tools can more easily process your distribution automatically.

You can find out more about this at Brian Cassidy's CPAN::Changes Kwalitee Service (http://changes.cpanhq.org), which is where I saw your module listed :-)

Cheers,
Neil

PS I'm doing this because I'm on a quest to help improve CPAN:
        http://questhub.io/realm/perl/quest/51f0337718ba7d3959000086
   You can check the status of your Changes files for all dists:
        http://changes.cpanhq.org/author/PSHANGOV
   If you choose you update the others, you can log them in comments on the quest :-)
